### PR TITLE
Add tests for duration formatting

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,85 @@
+import sys
+import types
+from datetime import datetime
+
+# Stub for the ``arrow`` package used by ``delt.main``.
+arrow_stub = types.ModuleType("arrow")
+
+
+class Arrow:
+    def __init__(self, dt: datetime) -> None:
+        self.dt = dt
+
+    def format(self, fmt: str) -> str:
+        if fmt == "YYYY-MM-DD HH:mm:ss":
+            return self.dt.strftime("%Y-%m-%d %H:%M:%S")
+        raise NotImplementedError
+
+    def __sub__(self, other: "Arrow"):
+        return self.dt - other.dt
+
+
+arrow_stub.Arrow = Arrow
+
+
+def get(date_str: str) -> Arrow:
+    return Arrow(datetime.strptime(date_str, "%Y-%m-%d %H:%M:%S"))
+
+
+def now() -> Arrow:
+    return Arrow(datetime.utcnow())
+
+
+arrow_stub.get = get
+arrow_stub.now = now
+
+parser = types.ModuleType("parser")
+
+
+class ParserError(Exception):
+    pass
+
+
+parser.ParserError = ParserError
+arrow_stub.parser = parser
+
+sys.modules.setdefault("arrow", arrow_stub)
+sys.modules.setdefault("arrow.parser", parser)
+
+# Minimal stub for the ``typer`` package so that ``delt.main`` can be imported.
+typer_stub = types.ModuleType("typer")
+
+
+class Typer:
+    def command(self, *args, **kwargs):
+        def decorator(func):
+            return func
+
+        return decorator
+
+
+typer_stub.Typer = Typer
+
+
+def Option(*args, **kwargs):
+    return None
+
+
+def Argument(*args, **kwargs):
+    return None
+
+
+def echo(*args, **kwargs):
+    pass
+
+
+class Exit(Exception):
+    pass
+
+
+typer_stub.Option = Option
+typer_stub.Argument = Argument
+typer_stub.echo = echo
+typer_stub.Exit = Exit
+
+sys.modules.setdefault("typer", typer_stub)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,15 @@
+from delt.main import calculate_delta_seconds, format_exact_duration_parts
+
+
+def test_format_exact_duration_parts_positive() -> None:
+    assert format_exact_duration_parts(90) == "1 minute, 30 seconds"
+
+
+def test_format_exact_duration_parts_negative() -> None:
+    assert format_exact_duration_parts(-3600) == "1 hour"
+
+
+def test_calculate_delta_seconds_exact() -> None:
+    start = "2024-01-01 00:00:00"
+    end = "2024-01-01 00:01:30"
+    assert calculate_delta_seconds(start, end, exact=True) == "1 minute, 30 seconds"


### PR DESCRIPTION
## Summary
- add unit tests verifying `format_exact_duration_parts` for positive and negative durations
- check `calculate_delta_seconds` returns the exact duration breakdown
- provide stubs for missing dependencies during testing

## Testing
- `ruff check tests/conftest.py tests/test_main.py delt/main.py`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683f4a1e93ac8331890b888da009fe9a