### PR TITLE
Fix numeric formatting for human-readable durations

### DIFF
--- a/delt/main.py
+++ b/delt/main.py
@@ -16,15 +16,29 @@ def format_duration(
         return format_exact_duration_parts(duration)
     if -now_diff < duration < now_diff:
         return "just now."
-    present = arrow.now()
-    delta = present.shift(seconds=duration)
+    seconds = abs(duration)
+    units = [
+        ("year", 31536000),
+        ("month", 2592000),
+        ("week", 604800),
+        ("day", 86400),
+        ("hour", 3600),
+        ("minute", 60),
+        ("second", 1),
+    ]
+    for name, count in units:
+        if seconds >= count:
+            value = seconds // count
+            break
+    else:
+        value, name = 0, "second"
+
+    result = f"{value} {name}{'s' if value != 1 else ''}"
     if not from_now:
-        return f"{delta.humanize(present, only_distance=True)}."
-    return (
-        f"{'in ' if duration < 0 else ''}"
-        f"{delta.humanize(present, only_distance=True)}"
-        f"{' ago' if duration > 0 else ''}."
-    )
+        return result + "."
+    if duration < 0:
+        return f"in {result}."
+    return f"{result} ago."
 
 
 def format_exact_duration_parts(duration: int) -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 import sys
 import types
-from datetime import datetime
+from datetime import datetime, timedelta
 
 # Stub for the ``arrow`` package used by ``delt.main``.
 arrow_stub = types.ModuleType("arrow")
@@ -17,6 +17,31 @@ class Arrow:
 
     def __sub__(self, other: "Arrow"):
         return self.dt - other.dt
+
+    def shift(self, *, seconds: int = 0) -> "Arrow":
+        return Arrow(self.dt + timedelta(seconds=seconds))
+
+    def humanize(self, other: "Arrow", *, only_distance: bool = False) -> str:
+        seconds = int(abs((self.dt - other.dt).total_seconds()))
+        units = [
+            ("year", 31536000),
+            ("month", 2592000),
+            ("week", 604800),
+            ("day", 86400),
+            ("hour", 3600),
+            ("minute", 60),
+            ("second", 1),
+        ]
+        for name, count in units:
+            if seconds >= count:
+                value = seconds // count
+                break
+        else:
+            value, name = 0, "second"
+        if value == 1:
+            article = "an" if name[0] in "aeiou" else "a"
+            return f"{article} {name}"
+        return f"{value} {name}{'s' if value != 1 else ''}"
 
 
 arrow_stub.Arrow = Arrow

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -13,3 +13,9 @@ def test_calculate_delta_seconds_exact() -> None:
     start = "2024-01-01 00:00:00"
     end = "2024-01-01 00:01:30"
     assert calculate_delta_seconds(start, end, exact=True) == "1 minute, 30 seconds"
+
+
+def test_calculate_delta_seconds_humanized_single_unit() -> None:
+    start = "2024-01-01 00:00:00"
+    end = "2024-01-01 01:00:00"
+    assert calculate_delta_seconds(start, end) == "1 hour."


### PR DESCRIPTION
## Summary
- ensure non-exact durations use numeric units
- expand arrow stub with `shift` and `humanize`
- add test covering human-readable output

## Testing
- `python -m pytest -q`
- `ruff check delt tests`
- `ruff format delt tests --check`


------
https://chatgpt.com/codex/tasks/task_e_6848895980b483319cbf905e2b4ebced