### PR TITLE
Fix countdown output logic

### DIFF
--- a/delt/main.py
+++ b/delt/main.py
@@ -99,7 +99,7 @@ def run_countdown(target: str, exact: bool = False) -> None:
                 typer.echo("Time's up!")
                 break
             typer.echo(
-                f"Remaining: {format_duration(remaining, from_now=True, exact=exact)}"
+                f"Remaining: {format_duration(-remaining, from_now=True, exact=exact)}"
             )
             time.sleep(1)
     except KeyboardInterrupt:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "delt"
-version = "0.5.1"
+version = "0.6.0"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -44,7 +44,13 @@ def test_run_countdown_date(monkeypatch) -> None:
     )
 
     monkeypatch.setattr(main.arrow, "get", fake_get)
-    monkeypatch.setattr(main.arrow, "now", lambda: next(times))
+    # The 'times' iterator is intentionally limited to two values to simulate specific timestamps.
+    # Adding a safeguard to prevent StopIteration errors if 'times' is exhausted.
+    monkeypatch.setattr(
+        main.arrow,
+        "now",
+        lambda: next(times, arrow_mod.Arrow(datetime(1970, 1, 1, 0, 0, 0))),
+    )
     monkeypatch.setattr(main.time, "sleep", lambda _: None)
 
     main.run_countdown("2028-07-07")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,3 +1,7 @@
+from datetime import datetime
+
+from delt import main
+
 from delt.main import calculate_delta_seconds, format_exact_duration_parts
 
 
@@ -19,3 +23,30 @@ def test_calculate_delta_seconds_humanized_single_unit() -> None:
     start = "2024-01-01 00:00:00"
     end = "2024-01-01 01:00:00"
     assert calculate_delta_seconds(start, end) == "1 hour."
+
+
+def test_run_countdown_date(monkeypatch) -> None:
+    outputs: list[str] = []
+
+    monkeypatch.setattr(main.typer, "echo", lambda msg: outputs.append(msg))
+
+    arrow_mod = main.arrow
+
+    def fake_get(date_str: str) -> arrow_mod.Arrow:
+        fmt = "%Y-%m-%d" if len(date_str) == 10 else "%Y-%m-%d %H:%M:%S"
+        return arrow_mod.Arrow(datetime.strptime(date_str, fmt))
+
+    times = iter(
+        [
+            arrow_mod.Arrow(datetime(2028, 7, 6, 0, 0, 0)),
+            arrow_mod.Arrow(datetime(2028, 7, 7, 0, 0, 0)),
+        ]
+    )
+
+    monkeypatch.setattr(main.arrow, "get", fake_get)
+    monkeypatch.setattr(main.arrow, "now", lambda: next(times))
+    monkeypatch.setattr(main.time, "sleep", lambda _: None)
+
+    main.run_countdown("2028-07-07")
+
+    assert outputs[0].startswith("Remaining: in ")

--- a/uv.lock
+++ b/uv.lock
@@ -50,7 +50,7 @@ wheels = [
 
 [[package]]
 name = "delt"
-version = "0.5.1"
+version = "0.6.0"
 source = { virtual = "." }
 dependencies = [
     { name = "arrow" },


### PR DESCRIPTION
## Summary
- invert the remaining time argument in `run_countdown`
- add regression test for countdown when only a date is supplied

## Testing
- `uv run python -m pytest -q` *(fails: Failed to download `python-dateutil`)*

------
https://chatgpt.com/codex/tasks/task_e_684ca16022988331a408128a8d0a486e