### PR TITLE
Add countdown test

### DIFF
--- a/delt/main.py
+++ b/delt/main.py
@@ -99,7 +99,7 @@ def run_countdown(target: str, exact: bool = False) -> None:
                 typer.echo("Time's up!")
                 break
             typer.echo(
-                f"Remaining: {format_duration(-remaining, from_now=True, exact=exact)}"
+                f"Remaining: {format_duration(-remaining, from_now=True, now_diff=0, exact=exact)}"
             )
             time.sleep(1)
     except KeyboardInterrupt:

--- a/delt/main.py
+++ b/delt/main.py
@@ -99,7 +99,7 @@ def run_countdown(target: str, exact: bool = False) -> None:
                 typer.echo("Time's up!")
                 break
             typer.echo(
-                f"Remaining: {format_duration(remaining, from_now=True, exact=exact)}"
+                f"Remaining: {format_duration(-remaining, from_now=True, exact=exact)}"
             )
             time.sleep(1)
     except KeyboardInterrupt:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,4 +1,8 @@
-from delt.main import calculate_delta_seconds, format_exact_duration_parts
+from delt.main import (
+    calculate_delta_seconds,
+    format_exact_duration_parts,
+    run_countdown,
+)
 
 
 def test_format_exact_duration_parts_positive() -> None:
@@ -19,3 +23,25 @@ def test_calculate_delta_seconds_humanized_single_unit() -> None:
     start = "2024-01-01 00:00:00"
     end = "2024-01-01 01:00:00"
     assert calculate_delta_seconds(start, end) == "1 hour."
+
+
+def test_run_countdown(monkeypatch) -> None:
+    outputs: list[str] = []
+
+    monkeypatch.setattr("delt.main.typer.echo", lambda msg: outputs.append(msg))
+
+    start_time = run_countdown.__globals__["arrow"].get("2024-01-01 00:00:00")
+    times = [
+        start_time,
+        start_time.shift(seconds=12),
+    ]
+
+    monkeypatch.setattr("delt.main.arrow.now", lambda: times.pop(0))
+    monkeypatch.setattr("delt.main.time.sleep", lambda _s: None)
+
+    target = start_time.shift(seconds=12).format("YYYY-MM-DD HH:mm:ss")
+    run_countdown(target)
+
+    assert "Remaining: in" in outputs[0]
+    assert outputs[-1] == "Time's up!"
+    assert len(outputs) == 2

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -28,7 +28,7 @@ def test_calculate_delta_seconds_humanized_single_unit() -> None:
 def test_run_countdown(monkeypatch) -> None:
     outputs: list[str] = []
 
-    monkeypatch.setattr("delt.main.typer.echo", lambda msg: outputs.append(msg))
+    monkeypatch.setattr("delt.main.typer.echo", lambda *args, **kwargs: outputs.append(args[0]))
 
     start_time = run_countdown.__globals__["arrow"].get("2024-01-01 00:00:00")
     times = [


### PR DESCRIPTION
## Summary
- add a countdown test verifying future countdown output
- adjust `run_countdown` to report future durations correctly

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ca164aa3c833190ddf494bd331945